### PR TITLE
Limit search space to (2t+1) max distance corridor

### DIFF
--- a/src/libfuzzymatch/levenshtein.cpp
+++ b/src/libfuzzymatch/levenshtein.cpp
@@ -25,8 +25,8 @@ uint32_t levenshteinCore(const std::vector<uint32_t> &s, const std::vector<uint3
  * Levenshtein distance for UTF-32 "strings".
  */
 uint32_t levenshtein(const std::vector<uint32_t> &s, const std::vector<uint32_t> &t) {
-	const size_t n(s.size()), m(t.size());
-	std::vector<uint32_t> current(m + 1), last(m + 1);
+    const size_t n(s.size()), m(t.size());
+    std::vector<uint32_t> current(m + 1), last(m + 1);
     return levenshteinCore(s, t, current, last);
 }
 
@@ -42,4 +42,55 @@ uint32_t levenshteinStatic(const std::vector<uint32_t> &s, const std::vector<uin
     }
 
     return levenshteinCore(s, t, current, last);
+}
+
+uint32_t levenshteinLimitCore(const std::vector<uint32_t> &s, const std::vector<uint32_t> &t,
+                         std::vector<uint32_t> &current, std::vector<uint32_t> &last,
+                         const uint32_t threshold) {
+    const size_t n(s.size()), m(t.size());
+
+    // Initialise with unmatched characters in t
+    for (size_t j = 0; j <= m; ++j) last[j] = j;
+
+    for (size_t i = 0; i < n; ++i) {
+        current[0] = i+1;
+        // min(start) = 1 as position 0 is handled above
+        const uint32_t start(std::max(1, (int)i - (int)threshold)), stop(std::min(m, i + threshold));
+        for (size_t j = start; j <= stop; ++j) {
+            current[j] = std::min(last[j] + 1, current[j-1] + 1); // insertion / deletion
+            current[j] = std::min(current[j], last[j-1] + (int)(s[i] != t[j-1])); // modification
+        }
+
+        // start needs to include position 0 and current[stop]
+        const auto it_start(current.cbegin() + std::max(0, (int)i - (int)threshold)),
+                   it_stop(current.cbegin() + stop + 1);
+        if (*std::min_element(it_start, it_stop) > threshold) {
+            return -1;
+        }
+        current.swap(last);
+    }
+    return last.back();
+}
+
+/**
+ * Levenshtein distance for UTF-32 "strings".
+ */
+uint32_t levenshteinLimit(const std::vector<uint32_t> &s, const std::vector<uint32_t> &t, const uint32_t threshold) {
+    const size_t n(s.size()), m(t.size());
+    std::vector<uint32_t> current(m + 1), last(m + 1);
+    return levenshteinLimitCore(s, t, current, last, threshold);
+}
+
+uint32_t levenshteinLimitStatic(const std::vector<uint32_t> &s, const std::vector<uint32_t> &t, const uint32_t threshold) {
+    const size_t m(t.size());
+    static std::vector<uint32_t> current;
+    static std::vector<uint32_t> last;
+
+    if (current.size() < m + 1) {
+        // Also: last.size < m + 1
+        current.resize(m + 1);
+        last.resize(m + 1);
+    }
+
+    return levenshteinLimitCore(s, t, current, last, threshold);
 }

--- a/src/libfuzzymatch/levenshtein.cpp
+++ b/src/libfuzzymatch/levenshtein.cpp
@@ -13,7 +13,7 @@ uint32_t levenshteinCore(const std::vector<uint32_t> &s, const std::vector<uint3
     for (size_t i = 0; i < n; ++i) {
         current[0] = i+1; // = last[0]+1, corresponds to unmatched character in s
         for (size_t j  = 1; j <= m; ++j) {
-            current[j] = std::min(last[j] + 1, current[j-1] + 1); // insertion / deletion
+            current[j] = std::min(last[j], current[j-1]) + 1; // insertion / deletion
             current[j] = std::min(current[j], last[j-1] + (int)(s[i] != t[j-1])); // modification
         }
         current.swap(last);
@@ -57,7 +57,7 @@ uint32_t levenshteinLimitCore(const std::vector<uint32_t> &s, const std::vector<
         // min(start) = 1 as position 0 is handled above
         const uint32_t start(std::max(1, (int)i - (int)threshold)), stop(std::min(m, i + threshold));
         for (size_t j = start; j <= stop; ++j) {
-            current[j] = std::min(last[j] + 1, current[j-1] + 1); // insertion / deletion
+            current[j] = std::min(last[j], current[j-1]) + 1; // insertion / deletion
             current[j] = std::min(current[j], last[j-1] + (int)(s[i] != t[j-1])); // modification
         }
 

--- a/src/libfuzzymatch/levenshtein.cpp
+++ b/src/libfuzzymatch/levenshtein.cpp
@@ -77,14 +77,25 @@ uint32_t levenshteinLimitCore(const std::vector<uint32_t> &s, const std::vector<
  */
 uint32_t levenshteinLimit(const std::vector<uint32_t> &s, const std::vector<uint32_t> &t, const uint32_t threshold) {
     const size_t n(s.size()), m(t.size());
+
+    // If the difference in word length exceeds the threshold, don't even bother
+    if ((m < n && n-m > threshold) || (m > n && m-n > threshold)) {
+        return -1;
+    }
+
     std::vector<uint32_t> current(m + 1), last(m + 1);
     return levenshteinLimitCore(s, t, current, last, threshold);
 }
 
 uint32_t levenshteinLimitStatic(const std::vector<uint32_t> &s, const std::vector<uint32_t> &t, const uint32_t threshold) {
-    const size_t m(t.size());
+    const size_t n(s.size()), m(t.size());
     static std::vector<uint32_t> current;
     static std::vector<uint32_t> last;
+
+    // If the difference in word length exceeds the threshold, don't even bother
+    if ((m < n && n-m > threshold) || (m > n && m-n > threshold)) {
+        return -1;
+    }
 
     if (current.size() < m + 1) {
         // Also: last.size < m + 1

--- a/src/libfuzzymatch/levenshtein.h
+++ b/src/libfuzzymatch/levenshtein.h
@@ -22,3 +22,27 @@ uint32_t levenshtein(const std::vector<uint32_t> &, const std::vector<uint32_t> 
  * @return The levenshtein distance between the two inputs.
  */
 uint32_t levenshteinStatic(const std::vector<uint32_t> &s, const std::vector<uint32_t> &t);
+
+/**
+ * Levenshtein distance for UTF-32 "strings" with maximum distance parameter.
+ * @param s First string input for levenshtein distance
+ * @param t Second string input for levenshtein distance
+ * @param threshold Maximum Levenshtein distance between s and t before aborting
+ * @return The Levenshtein distance between the two inputs, or -1 if it exceeds the threshold.
+ */
+uint32_t levenshteinLimit(const std::vector<uint32_t> &, const std::vector<uint32_t> &, const uint32_t);
+
+/**
+ * Limited Levenshtein distance for UTF-32 "strings" using static storage for less allocations.
+ *
+ * The two temporary used arrays are statically allocated internally, i.e. are
+ * always expanded to the maximum size of the second input and never scaled down.
+ * Although this offers better performance, you need to be aware that large
+ * inputs will increase the memory usage for the whole lifespan of the procress.
+ *
+ * @param s First string input for levenshtein distance
+ * @param t Second string input for levenshtein distance
+ * @param threshold Maximum Levenshtein distance between s and t before aborting
+ * @return The Levenshtein distance between the two inputs, or -1 if it exceeds the threshold.
+ */
+uint32_t levenshteinLimitStatic(const std::vector<uint32_t> &, const std::vector<uint32_t> &, const uint32_t);


### PR DESCRIPTION
This is the simple version that uses O(m) space instead of O(d), but at least it seems to work.

Algorithmic idea: if we have an upper bound d on the Levenshtein distance we are interested in (say, 3), we don't need to evaluate the entire O(n_m) matrix. Instead, it suffices to compute a corridor of width 2d+1 around the diagonal of the matrix in time O(n_d). The proof is left as an exercise to the reader ;)

Furthermore, we can abort the search if the minimum Levenshtein distance between a prefix of s and a prefix of t exceeds d, we can abort the computation and report that the threshold was exceeded. This is obviously correct as the Levenshtein distance increases monotonically as we add arbitrary suffixes to the strings.

Possible improvements:
- [x] if `|n-m|>d`, we don't need to look at the strings at all, as their Levenshtein distance cannot be ≤ d
- [x] if `n>m`, flip the strings → O(min(n,m)*t). Unclear whether this provides further benefits after the above suggestion has been implemented.
- [x] document the code
- [x] ~~add MathJax support to GitHub flavoured markdown~~ lose hope
